### PR TITLE
Fix chat downloading mode

### DIFF
--- a/TwcLazer.py
+++ b/TwcLazer.py
@@ -102,5 +102,6 @@ if UserIn["withchat"] is True:
 
 for task in tasks:
     task.start()
+for task in tasks:
     task.join()
  

--- a/twitcasting/TwitcastWebsocket.py
+++ b/twitcasting/TwitcastWebsocket.py
@@ -146,4 +146,3 @@ class TwitcastEventSocket:
         url = websocket_url
         async with websockets.connect(url) as ws:
             await TwitcastEventSocket.eventhandler(ws, TwAPI, filename, printChat, CommentFormatString, GiftFormatString)
-            await asyncio.Future()  # run forever


### PR DESCRIPTION
It seems to be broken in 5b0b75b85b6534e4f5128e0a55474721c6b7fa67. Calling `join()` will cause main thread to block until thread terminates, which means `start()` of the second task will be called only when first one exits.
It worked before the change because `join()` gets called automatically for each subtask after main thread exits, but it's probably better to call it explicitly.

This solution still has issue of not handling KeyboardInterrupt well (needs to be pressed twice, to terminate both threads), but fixing it requires noticeable amount of code, so removing threading alltogether and starting both tasks in a single event loop might be a better way to do it. Tell me if you want PR for that.

`TwitcastEventSocket.RecieveMessages` had infinite loop at the end, causing whole script to hang up after finishing download with chat, so second commit removes it.