### PR TITLE
Add cookies support

### DIFF
--- a/TwcLazer.py
+++ b/TwcLazer.py
@@ -13,6 +13,7 @@ import helpers.CLIhelper as CLIhelper
 import twitcasting.TwitcastAPI as TwitcastAPI
 import twitcasting.TwitcastWebsocket as TwitcastWebsocket
 import utils.ChatFormatter as ChatFormatter
+from utils.CookiesHandler import CookiesHandler
 
 parser = argparse.ArgumentParser(add_help=False)
 parser.add_argument("-h", "--help", action="store_true")
@@ -20,6 +21,7 @@ parser.add_argument("-u", "--username", type=str)
 parser.add_argument("-q", "--quality", type=str, default="low")
 parser.add_argument("-ff", "--fileformat", type=str, default="Twitcasting-%%Un-%%Dy_%%Dm_%%Dd")
 parser.add_argument("-p", "--path", type=str, default=None)
+parser.add_argument("-c", "--cookies", type=str, default=None)
 
 parser.add_argument("-nW", "--noWarn", action="store_true", default=False)
 parser.add_argument("-nR", "--noRetry", action="store_true", default=False)
@@ -51,11 +53,18 @@ UserIn = {
     "giftformat": args.giftFormat
 }
 
+if args.cookies is not None:
+    UserIn["cookies"] = CookiesHandler.load_cookies(args.cookies)
+else:
+    UserIn["cookies"] = None
+
 if UserIn["path"] is not None and not os.path.exists(UserIn["path"]):
     print(f"{UserIn['path']} is not a valid directory.")
     exit()
 
-if TwitcastAPI.TwitcastingAPI.is_live(UserIn["username"]) == False:
+if TwitcastAPI.TwitcastingAPI.user_is_live(UserIn["username"], UserIn["cookies"]):
+    print(f"{UserIn['username']} is live, downloading")
+else:
     print(f"{UserIn['username']} is not live.")
     exit()
 

--- a/twitcasting/TwitcastAPI.py
+++ b/twitcasting/TwitcastAPI.py
@@ -1,27 +1,27 @@
 # Twitcasting Downloader API Functions
 import requests
 import json
+
 import twitcasting.TwitcastStream as TwitcastStream
+from utils.CookiesHandler import CookiesHandler
 
 class TwitcastingAPI:
     '''Class for the functional Twitcasting API'''
     
     # Get Token
-    @staticmethod
-    def GetToken(movieID) -> TwitcastStream.HappyToken:
+    def GetToken(self, movieID) -> TwitcastStream.HappyToken:
         HappyTokenURL = "https://twitcasting.tv/happytoken.php"
         HappyTokenData = {'movie_id': movieID}
-        HappyTokenRequest = requests.post(HappyTokenURL, data=HappyTokenData)
+        HappyTokenRequest = self.session.post(HappyTokenURL, data=HappyTokenData)
         
         HappyTokenRequestData = json.loads(HappyTokenRequest.text)
         
         return TwitcastStream.HappyToken(HappyTokenRequestData["token"])
         
     # Get Current Stream
-    @staticmethod
-    def GetStream(username) -> TwitcastStream.StreamServer:
+    def GetStream(self, username) -> TwitcastStream.StreamServer:
         StreamServerURL = f"https://twitcasting.tv/streamserver.php?target={username}&mode=client"
-        StreamServer_Request = requests.get(StreamServerURL)
+        StreamServer_Request = self.session.get(StreamServerURL)
         
         if StreamServer_Request.status_code != 200:
             print("User is not live or invalid username.")
@@ -45,10 +45,9 @@ class TwitcastingAPI:
         )
     
     # Get Stream Info
-    @staticmethod
-    def GetStreamInfo(movieID, token) -> TwitcastStream.TwitcastStream_:
+    def GetStreamInfo(self, movieID, token) -> TwitcastStream.TwitcastStream_:
         TwitcastStreamURL = f"https://frontendapi.twitcasting.tv/movies/{movieID}/status/viewer?token={token.token}"
-        TwitcastStream_Request = requests.get(TwitcastStreamURL)
+        TwitcastStream_Request = self.session.get(TwitcastStreamURL)
         
         if TwitcastStream_Request.status_code != 200:
             print("User is not live or invalid username.")
@@ -69,28 +68,40 @@ class TwitcastingAPI:
             TwitcastStreamData.get("movie").get("pin_message"))
         
     # Get PubSub URL
-    @staticmethod
-    def GetPubSubURL(movieID) -> TwitcastStream.EventsPubSubURL:
+    def GetPubSubURL(self, movieID) -> TwitcastStream.EventsPubSubURL:
         PubSubURL = "https://twitcasting.tv/eventpubsuburl.php"
         PubSubData = {'movie_id': movieID}
-        PubSubRequest = requests.post(PubSubURL, data=PubSubData)
+        PubSubRequest = self.session.post(PubSubURL, data=PubSubData)
         
         PubSubRequestData = json.loads(PubSubRequest.text)
         
         return TwitcastStream.EventsPubSubURL(PubSubRequestData["url"])
     
     @staticmethod
-    def is_live(username) -> bool:
-        is_user_live = requests.get(f"https://twitcasting.tv/userajax.php?c=islive&u={username}")
+    def user_is_live(username, cookies=None) -> bool:
+        url = f"https://twitcasting.tv/userajax.php?c=islive&u={username}"
+        is_user_live = requests.get(url, cookies=cookies)
+        if is_user_live.status_code != 200:
+            print(f"got status {is_user_live.status_code} when checking if user {username} is live, '{is_user_live.text}'")
         if is_user_live.text == "0":
             return False
         else:
             return True
-    
+
+    def is_live(self):
+        return self.user_is_live(self.userInput["username"], self.session.cookies)
+
+    @property
+    def cookies_header(self):
+        return CookiesHandler.get_cookies_header(self.session.cookies, "https://twitcasting.tv")
+
     def __init__(self, UserInput) -> None:
         # Input TwitcastStream.py Userinput object
         self.userInput = UserInput
-        self.CurrentStream = TwitcastingAPI.GetStream(self.userInput["username"])
-        self.CurrentStreamToken = TwitcastingAPI.GetToken(self.CurrentStream.movie_id)
-        self.CurrentStreamInfo = TwitcastingAPI.GetStreamInfo(self.CurrentStream.movie_id, self.CurrentStreamToken)
-        self.CurrentStreamPubSubURL = TwitcastingAPI.GetPubSubURL(self.CurrentStream.movie_id)
+        self.session = requests.Session()
+        self.session.cookies = self.userInput["cookies"] or requests.cookies.RequestsCookieJar()
+
+        self.CurrentStream = self.GetStream(self.userInput["username"])
+        self.CurrentStreamToken = self.GetToken(self.CurrentStream.movie_id)
+        self.CurrentStreamInfo = self.GetStreamInfo(self.CurrentStream.movie_id, self.CurrentStreamToken)
+        self.CurrentStreamPubSubURL = self.GetPubSubURL(self.CurrentStream.movie_id)

--- a/twitcasting/TwitcastWebsocket.py
+++ b/twitcasting/TwitcastWebsocket.py
@@ -27,7 +27,7 @@ class TwitcastVideoSocket:
     async def listen(url, TwitcastApiOBJ, filename, NoRetry=False):
         recieved_bytes = 0
         while True:
-            async with websockets.connect(url) as ws:
+            async with websockets.connect(url, extra_headers=TwitcastApiOBJ.cookies_header) as ws:
                 try:
                     while True:
                         with open(f"{filename}.mp4".replace(":", "-"), 'ab') as filewriter:
@@ -38,7 +38,7 @@ class TwitcastVideoSocket:
                                 filewriter.write(msg)
                 
                 except Exception:
-                    if TwitcastApiOBJ.is_live(TwitcastApiOBJ.userInput["username"]) == True:
+                    if TwitcastApiOBJ.is_live():
                         if NoRetry == True:
                             print(f"[WebSocket] Connection Dropped, Closing Socket..." + " "*30, end='\r')
                             await ws.close()
@@ -113,7 +113,7 @@ class TwitcastEventSocket:
     # Todo: Allow for full customization of the format
     # e.g raw json, only specific attributes, etc.
     async def eventhandler(websocket, TwitcastApiOBJ, filename, printChat, CommentFormatString, GiftFormatString):
-        while TwitcastApiOBJ.is_live(TwitcastApiOBJ.userInput["username"]) == True:
+        while TwitcastApiOBJ.is_live():
             message = await websocket.recv()
             with open(f"{filename}.txt".replace(":", "-"), 'a+', encoding="utf8") as f:
                 eventData = json.loads(message)
@@ -144,5 +144,5 @@ class TwitcastEventSocket:
 
     async def RecieveMessages(websocket_url, TwAPI, filename, printChat, CommentFormatString, GiftFormatString):
         url = websocket_url
-        async with websockets.connect(url) as ws:
+        async with websockets.connect(url, extra_headers=TwAPI.cookies_header) as ws:
             await TwitcastEventSocket.eventhandler(ws, TwAPI, filename, printChat, CommentFormatString, GiftFormatString)

--- a/utils/CookiesHandler.py
+++ b/utils/CookiesHandler.py
@@ -1,0 +1,27 @@
+from http import cookiejar
+import requests
+
+class CookiesHandler:
+
+    @staticmethod
+    def load_cookies(path):
+        cookie_jar = cookiejar.MozillaCookieJar(path)
+        try:
+            cookie_jar.load()
+            print(f"cookies successfully loaded from {path}")
+        except FileNotFoundError:
+            print(f"failed to load cookies from {path}: no such file")
+            return None
+        except (cookiejar.LoadError, OSError) as e:
+            print(f"failed to load cookies from {path}: {e}")
+            return None
+        return cookie_jar
+
+    @staticmethod
+    def get_cookies_header(cookie_jar, url):
+        # generate custom header from cookies to use with Websockets
+        # connect() method, which accepts headers but not CookieJar
+        r = requests.Request('GET', url)
+        cookie_string = requests.cookies.get_cookie_header(cookie_jar, r)
+        return {'Cookie': cookie_string}
+


### PR DESCRIPTION
Allows downloading lives marked as including sensitive content (basically requiring login to view) and lives streamed in private groups. For the second case channel won't even be shown as online to anyone except group members, so even live status request should use cookies to work.

Websockets urls for such limited streams also check cookies, and it seems `connect` method of websocket object only accepts cookies as custom header (https://github.com/python-websockets/websockets/issues/420#issuecomment-394064616), so it ended up being generated with a helper method `CookiesHandler.get_cookies_header`, which might be a bit not obvious but seems to work.

Since most `TwitcastingAPI` functions got changed from static to instance methods, their signatures can be now simplified to accept no parameters but `self`. Let me know if this is desirable.

