### PR TITLE
Add support for password-protected streams

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Optional arguments
   -ff, --fileformat FORMAT    filename format for the stream
   -p, --path PATH             Path to download the stream to
   -q, --quality [low, best, worst]
+  -s, --secret SECRET         Secret word, used to access password-protected streams
 
 Flags
   -nW, --noWarn               Don't display lagspike warning when downloading high bitrate streams

--- a/TwcLazer.py
+++ b/TwcLazer.py
@@ -22,6 +22,7 @@ parser.add_argument("-q", "--quality", type=str, default="low")
 parser.add_argument("-ff", "--fileformat", type=str, default="Twitcasting-%%Un-%%Dy_%%Dm_%%Dd")
 parser.add_argument("-p", "--path", type=str, default=None)
 parser.add_argument("-c", "--cookies", type=str, default=None)
+parser.add_argument("-s", "--secret", type=str, default=None)
 
 parser.add_argument("-nW", "--noWarn", action="store_true", default=False)
 parser.add_argument("-nR", "--noRetry", action="store_true", default=False)
@@ -44,6 +45,7 @@ UserIn = {
     "fileformat": args.fileformat,
     "withchat": args.withChat,
     "path": args.path,
+    "secret": args.secret,
     
     "noWarn": args.noWarn,
     "noRetry": args.noRetry,

--- a/helpers/CLIhelper.py
+++ b/helpers/CLIhelper.py
@@ -25,6 +25,7 @@ Optional arguments
   -ff, --fileformat FORMAT    filename format for the stream
   -p, --path PATH             Path to download the stream to
   -q, --quality [low, best, worst]
+  -s, --secret SECRET         Secret word, used to access password-protected streams
 
 Flags
   -nW, --noWarn               Don't display lagspike warning when downloading high bitrate streams

--- a/twitcasting/TwitcastStream.py
+++ b/twitcasting/TwitcastStream.py
@@ -49,6 +49,9 @@ class EventsPubSubURL:
 class HappyToken:
     '''Twitcasting Happytoken'''
     token: str
+
+class PasswordCookie(str):
+    '''Used to access password-protected stream'''
     
 @dataclass
 class StreamEvent_Comment:

--- a/utils/CookiesHandler.py
+++ b/utils/CookiesHandler.py
@@ -1,4 +1,5 @@
 from http import cookiejar
+
 import requests
 
 class CookiesHandler:
@@ -25,3 +26,9 @@ class CookiesHandler:
         cookie_string = requests.cookies.get_cookie_header(cookie_jar, r)
         return {'Cookie': cookie_string}
 
+    @staticmethod
+    def to_dict(cookie_jar):
+        # unlike RequestsCookieJar, FileCookieJar doesn't provide
+        # dictionary-like interface for getting cookies values,
+        # so this method can be used instead
+        return {cookie.name: cookie.value for cookie in cookie_jar}


### PR DESCRIPTION
It seems that the API for retrieving a token got changed, and since it is now impossible to see how frontend would submit a password to HappyToken endpoint, I ended up rewriting `TwitcastingAPI.GetToken` to use url currently used by frontend, so token is not Happy anymore. Nonetheless, `TwitcastStream.HappyToken` wasn't renamed to limit the scope of the change to `TwitcastingAPI`.

Plenty of new diagnostic and error messages were added, so in addition to reviewing, proofreading might be necessarily. Most notably, one of the messages in `TwitcastingAPI.GetPasswordCookie` references the command line option used to pass a password. Perhaps it should be reworded to mention documentation, instead of hardcoding the option value?

Exceptions in `GetToken` and `GetStream` caused by password-protected and age-restricted streams are currently left uncaught to help with debugging possible problems. Additional messages should still give user enough information about the error.