### PR TITLE
Revert GetToken back to use HappyToken endpoint

### DIFF
--- a/twitcasting/TwitcastAPI.py
+++ b/twitcasting/TwitcastAPI.py
@@ -12,9 +12,12 @@ class TwitcastingAPI:
 
     # Get Token
     def GetToken(self, movieID, password=None) -> TwitcastStream.HappyToken:
-        TokenURL = f"https://frontendapi.twitcasting.tv/movies/{movieID}/token"
-        TokenData = {"password": password} if password is not None else {}
-        TokenRequest = self.session.post(TokenURL, data=TokenData)
+
+        HappyTokenURL = "https://twitcasting.tv/happytoken.php"
+        HappyTokenData = {'movie_id': movieID}
+        if password is not None:
+            HappyTokenData["password"] = password
+        TokenRequest = self.session.post(HappyTokenURL, data=HappyTokenData)
 
         if TokenRequest.status_code != 200:
             print(f"Got status code {TokenRequest.status_code} when requesting token for movie {movieID}")


### PR DESCRIPTION
Unless I am missing something, it seems that about a day ago API endpoint for requesting a token got changed to check the request for headers `x-web-authorizekey` and `x-web-sessionid`, set by js. Some of the other endpoinds at frontendapi.twitcasting.tv were checking for it before, but none of them were required for download.

I changed code back to use `/happytoken.php`, and it appears to work fine. Since the reason for changing endpoint was adding support for password-protected streams, I tried passing the same "password" parameter new API uses, and apparently it also works.

Video stream websocket urls gets password appended to it as parameter instead of being passed in cookie value, and while using cookies still works, I believe it's worth changing, since it allows to remove `TwitcastingAPI.cookies_header` and related code. I will submit is as part of a separate pull request.