### PR TITLE
Improve password and cookies handling

### DIFF
--- a/twitcasting/TwitcastAPI.py
+++ b/twitcasting/TwitcastAPI.py
@@ -59,6 +59,10 @@ class TwitcastingAPI:
     def GetUserPage(self, username):
         user_url = f"https://twitcasting.tv/{username}/"
         page = self.session.get(user_url)
+
+        if page.headers.get('Set-Cookie', '').find('tc_ss=deleted') > -1:
+            print("Logged out by server, session stored in cookies file is no longer valid")
+
         if page.status_code != 200:
             print(f"Got status code {page.status_code} when requesting {user_url}")
         return page

--- a/twitcasting/TwitcastAPI.py
+++ b/twitcasting/TwitcastAPI.py
@@ -56,19 +56,19 @@ class TwitcastingAPI:
 
         return TwitcastStream.HappyToken(Token)
 
-    def GetUserPage(self, username):
+    def GetUserPage(self, username) -> requests.Response:
         user_url = f"https://twitcasting.tv/{username}/"
         page = self.session.get(user_url)
-
         if page.headers.get('Set-Cookie', '').find('tc_ss=deleted') > -1:
             print("Logged out by server, session stored in cookies file is no longer valid")
-
         if page.status_code != 200:
             print(f"Got status code {page.status_code} when requesting {user_url}")
         return page
 
-    def GetPasswordCookie(self, user_page, password=None) -> Optional[TwitcastStream.PasswordCookie]:
-        '''Check if ongoing stream is password-restricted, submit password if required'''
+    def SubmitPassword(self, user_page: requests.Response, password: Optional[str] = None) -> requests.Response:
+        '''Check if user_page contains password input form, submit password if required.
+        If password gets accepted, request gets redirected to real user page.
+        Return response (or original user_page if no password required) for further processing'''
         user_url = user_page.url
 
         flags = re.DOTALL | re.IGNORECASE
@@ -76,27 +76,33 @@ class TwitcastingAPI:
         re_session_id = 'name="cs_session_id" value="(.*?)"'
         password_form = re.search(re_form, user_page.text, flags)
         if password_form is None:
-            print("Stream is not password-restricted")
-            return None
+            # didn't get asked for password, stream is either unrestricted
+            # or password is already present in cookies loaded from file
+            return user_page
         session_id = re.search(re_session_id, password_form.group(1), flags)
         if session_id is None:
             print(f"Unable to extract session_id from secret word form at {user_url}")
-            return None
+            return user_page
         if password is None:
             print("Current stream appears to be password-restricted. Password can be provided with --secret argument")
-            return None
+            return user_page
 
         # In response to submitting correct password server sets cookie "wpass",
         # used then to get stream data and access websocket url
         data = {"password": password, "cs_session_id": session_id.group(1)}
-        self.session.post(user_url, data=data)
-        password_value = CookiesHandler.to_dict(self.session.cookies).get("wpass")
-        password_cookie = TwitcastStream.PasswordCookie(password_value) if password_value else None
+        page = self.session.post(user_url, data=data)
 
-        if password_cookie is not None:
+        password_form = re.search(re_form, page.text, flags)
+        if password_form is None:
             print(f"Password accepted for livestream {user_url}")
         else:
             print(f"Password {password} was not accepted for livestream {user_url}")
+        return page
+
+    def GetPasswordCookie(self, username) -> Optional[TwitcastStream.PasswordCookie]:
+        '''Password cookie normally received in SubmitPassword, but can be loaded from cookies file'''
+        password_value = self.session.cookies.get("wpass", path=f"/{username}")
+        password_cookie = TwitcastStream.PasswordCookie(password_value) if password_value else None
         return password_cookie
 
     # Get Current Stream
@@ -187,8 +193,8 @@ class TwitcastingAPI:
         self.session.cookies = self.userInput["cookies"] or requests.cookies.RequestsCookieJar()
 
         user_page = self.GetUserPage(self.userInput["username"])
-        password = self.GetPasswordCookie(user_page, self.userInput["secret"])
-        user_page = self.GetUserPage(self.userInput["username"])
+        user_page = self.SubmitPassword(user_page, self.userInput["secret"])
+        password = self.GetPasswordCookie(self.userInput["username"])
         sessionID = self.GetAuthSessionID(user_page)
 
         self.CurrentStream = self.GetStream(self.userInput["username"])

--- a/twitcasting/TwitcastWebsocket.py
+++ b/twitcasting/TwitcastWebsocket.py
@@ -4,6 +4,7 @@ import twitcasting.TwitcastStream as TwitcastStream
 import utils.ChatFormatter as ChatFormatter
 import helpers.CLIhelper as CLIhelper
 import json
+import urllib
 
 # Twitcasting Video Socket
 # Get Video Data from the twitcasting websocket
@@ -67,10 +68,24 @@ class TwitcastVideoSocket:
         if url == None and quality == "low":
             print("Unable to locate MobileSource, Defaulting to Main.")
             url = qualities["best"]
-            
-        
+        password = TwitcastApiOBJ.GetPasswordCookie(TwitcastApiOBJ.userInput["username"])
+        if password is not None:
+            url = update_url(url, [("word", password)])
+
         await TwitcastVideoSocket.listen(url, TwitcastApiOBJ, filename, NoRetry)
-            
+
+def update_url(url, params):
+    url = urllib.parse.unquote(url)
+    parsed_url = urllib.parse.urlparse(url)
+    get_args = parsed_url.query
+    parsed_get_args = urllib.parse.parse_qsl(get_args)
+    parsed_get_args.extend(params)
+    encoded_get_args = urllib.parse.urlencode(parsed_get_args, doseq=True)
+    return urllib.parse.ParseResult(
+        parsed_url.scheme, parsed_url.netloc, parsed_url.path,
+        parsed_url.params, encoded_get_args, parsed_url.fragment
+    ).geturl()
+
 # Twitcast Event Socket
 # Socket for recieving events from the chat and gifts things like that
 class TwitcastEventSocket:

--- a/utils/CookiesHandler.py
+++ b/utils/CookiesHandler.py
@@ -16,7 +16,10 @@ class CookiesHandler:
         except (cookiejar.LoadError, OSError) as e:
             print(f"failed to load cookies from {path}: {e}")
             return None
-        return cookie_jar
+        requests_cookie_jar = requests.cookies.RequestsCookieJar()
+        for cookie in cookie_jar:
+            requests_cookie_jar.set_cookie(cookie)
+        return requests_cookie_jar
 
     @staticmethod
     def get_cookies_header(cookie_jar, url):

--- a/utils/CookiesHandler.py
+++ b/utils/CookiesHandler.py
@@ -32,10 +32,3 @@ class CookiesHandler:
         r = requests.Request('GET', url)
         cookie_string = requests.cookies.get_cookie_header(cookie_jar, r)
         return {'Cookie': cookie_string}
-
-    @staticmethod
-    def to_dict(cookie_jar):
-        # unlike RequestsCookieJar, FileCookieJar doesn't provide
-        # dictionary-like interface for getting cookies values,
-        # so this method can be used instead
-        return {cookie.name: cookie.value for cookie in cookie_jar}

--- a/utils/CookiesHandler.py
+++ b/utils/CookiesHandler.py
@@ -8,7 +8,7 @@ class CookiesHandler:
     def load_cookies(path):
         cookie_jar = cookiejar.MozillaCookieJar(path)
         try:
-            cookie_jar.load()
+            cookie_jar.load(ignore_expires=True)
             print(f"cookies successfully loaded from {path}")
         except FileNotFoundError:
             print(f"failed to load cookies from {path}: no such file")
@@ -18,6 +18,10 @@ class CookiesHandler:
             return None
         requests_cookie_jar = requests.cookies.RequestsCookieJar()
         for cookie in cookie_jar:
+            if cookie.expires == 0:
+                cookie.expires = None
+            if cookie.path != '/':
+                cookie.path_specified = True
             requests_cookie_jar.set_cookie(cookie)
         return requests_cookie_jar
 


### PR DESCRIPTION
Improve cookies loading procedure to handle session cookies and multiple cookies with the same key, allowing password cookie to be stored in cookies file in addition to --secret argument (cookie for a given password doesn't stay the same forever, so it shouldn't be relied on too much though). Update password submitting, removing second request for user page when unnecessarily, pass password to stream websocket as url parameter instead of cookie value.

Now that I got better understanding on how cookies work in general and how this specific server works with passwords, I was able to replace shortcuts taken in first implementation with more conventional way to do things, hopefully making it less likely to break after a possible server update.