### PR TITLE
Fix errors in filename generation

### DIFF
--- a/TwcLazer.py
+++ b/TwcLazer.py
@@ -84,7 +84,7 @@ FileFormat_Translations = {
     "%%Dd" : str(today.day),
     "%%Un" : UserIn["username"]
 }
-UserIn["fileformat"] = ChatFormatter.strTranslate(UserIn["fileformat"], FileFormat_Translations)
+UserIn["fileformat"] = ChatFormatter.FormatFilename(UserIn["fileformat"], FileFormat_Translations)
 
 if UserIn["path"] is not None:
     UserIn["fileformat"] = os.path.join(UserIn["path"], UserIn["fileformat"])

--- a/twitcasting/TwitcastWebsocket.py
+++ b/twitcasting/TwitcastWebsocket.py
@@ -31,7 +31,7 @@ class TwitcastVideoSocket:
             async with websockets.connect(url, extra_headers=TwitcastApiOBJ.cookies_header) as ws:
                 try:
                     while True:
-                        with open(f"{filename}.mp4".replace(":", "-"), 'ab') as filewriter:
+                        with open(f"{filename}.mp4", 'ab') as filewriter:
                             msg = await asyncio.wait_for(ws.recv(), timeout=25) # https://github.com/HoloArchivists/TwcLazer/issues/5
                             if len(msg) != 1108:
                                 recieved_bytes += len(msg)
@@ -130,7 +130,7 @@ class TwitcastEventSocket:
     async def eventhandler(websocket, TwitcastApiOBJ, filename, printChat, CommentFormatString, GiftFormatString):
         while TwitcastApiOBJ.is_live():
             message = await websocket.recv()
-            with open(f"{filename}.txt".replace(":", "-"), 'a+', encoding="utf8") as f:
+            with open(f"{filename}.txt", 'a+', encoding="utf8") as f:
                 eventData = json.loads(message)
                 
                 try:

--- a/utils/ChatFormatter.py
+++ b/utils/ChatFormatter.py
@@ -2,15 +2,12 @@
 # Convert percent strings into information
 
 # Translation of information for strings
-def strTranslate(original_text,dictionary_of_translations):
+def strTranslate(original_text, dictionary_of_translations):
     out = original_text
-    for keys,target in dictionary_of_translations.items():
-        if keys in out:
-            out = out.replace(keys, target)
-        else:
-            pass
-#        trans = str.maketrans(target,dictionary_of_translations[target])
-#        out = out.translate(trans)
+    for key, target in dictionary_of_translations.items():
+        if key in out:
+            target = "" if target is None else target
+            out = out.replace(key, str(target))
     return out
 
 class ChatFormatter:
@@ -48,4 +45,3 @@ class ChatFormatter:
             "%%Sp" : ParsedComment.sender_profileImage
         }
         return strTranslate(formatString, gift_translations)
-    

--- a/utils/ChatFormatter.py
+++ b/utils/ChatFormatter.py
@@ -10,6 +10,16 @@ def strTranslate(original_text, dictionary_of_translations):
             out = out.replace(key, str(target))
     return out
 
+def sanitizeFilename(filename):
+    bad_characters = '\\/:*?<>|"'
+    return filename.translate(str.maketrans(bad_characters, "_" * len(bad_characters)))
+
+def FormatFilename(filename, translations):
+    filename = strTranslate(filename, translations)
+    filename = sanitizeFilename(filename)
+    return filename
+
+
 class ChatFormatter:
     
     def FormatComments(formatString, ParsedComment):


### PR DESCRIPTION
Stream title might contain other illegal characters other than `:`, which should also be removed.
Substitution values for file name are taken from `TwitcastingAPI.CurrentStreamInfo` structure. It uses `None` as placeholder of absent values and might be numbers, and `ChatFormatter.strTranslate` was only expecting strings as substitution values.