### PR TITLE
Add a few reconnection-related improvements

### DIFF
--- a/twitcasting/TwitcastAPI.py
+++ b/twitcasting/TwitcastAPI.py
@@ -34,7 +34,9 @@ class TwitcastingAPI:
         if player_page.status_code != 200:
             print(f"Got status code {player_page.status_code} when requesting PlayerPage2")
         try:
-            return get_salt(player_page.text)
+            salt = get_salt(player_page.text)
+            print(f'Current salt is {salt}')
+            return salt
         except Exception as e:
             msg = "Failed to extract value used to generate authorization headers from PlayerPage. Check for updates and report this issue on GitHub along with the error message above if it happens on the most recent version"
             raise TwitcastingAPIError(msg) from e
@@ -202,6 +204,11 @@ class TwitcastingAPI:
         username = self.userInput["username"]
         user_url = f"https://twitcasting.tv/{username}"
         return CookiesHandler.get_cookies_header(self.session.cookies, user_url)
+
+    def refetch(self):
+        new_instance = TwitcastingAPI(self.userInput)
+        print(f"fetched new TwitcastingAPI instance, {new_instance.CurrentStreamToken=}, {new_instance.CurrentStreamInfo=}")
+        return new_instance
 
     def __init__(self, UserInput) -> None:
         # Input TwitcastStream.py Userinput object


### PR DESCRIPTION
I encountered a few bugs caused by blanket `except Exception` in TwitcastWebsocket.py, most notably absence of free space on hdd causing endless reconnect attempts. This PR attempts to address it by adding reconnect attempts limit (set to 4, adjust to your liking) and more granular exception handling.

One notable change is starting a new file after every reconnect by appending `_1`, `_2` etc suffixes to the filename. In my experience, keeping appending to the same file messes up the timestamps, and with multiple files merging them with ffmpeg takes care of that. When connection to twitcast servers is especially bad and download drops frequently, number of files serves as an indication of how bad it is for specific recording, which is a bit less obvious with a single file.