### PR TITLE
Update regexp in salt extraction code

### DIFF
--- a/utils/Salt.py
+++ b/utils/Salt.py
@@ -68,7 +68,7 @@ def get_salt_offset(js):
     # extracting array offset for salt value from the place in code that makes use of it.
     # Since array can be decoded and rotated to right position, all that is left is to
     # get the salt value out of it by its offset
-    re_salt_offset = 'null!=\([a-z]=[a-z]\[[a-z]\(\d+\)\]\)\?[a-z]:[a-z]\((\d+)\),[a-z]\),'
+    re_salt_offset = 'null!=\([a-z]=[a-z]\.salt\)\?[a-z]:[a-z]\((\d+)\),[a-z]\)'
     match = re.search(re_salt_offset, js)
     return int(match.groups()[0])
 


### PR DESCRIPTION
It's the regexp in `get_salt_offset` again.
Curiously, js code attempts to access a named attribute before falling back to offset, allowing to greatly simplify the regexp. The attribute is not set anywhere in the code, at least in clear text, so it might be part of ongoing refactoring.