### PR TITLE
Add requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+requests
+websockets>=13.0


### PR DESCRIPTION
List all (both) dependencies, specifying minimal supported version of `websockets`.
It is possible to make older versions work along with the latest ones by utilizing conditional imports, but it doesn't seem to be worth the effort with version 15.0 supporting Python 3.9